### PR TITLE
v0.1.0.19.88 -- Fix Report()

### DIFF
--- a/headers/Profile/Profiler.hpp
+++ b/headers/Profile/Profiler.hpp
@@ -30,6 +30,18 @@ namespace Profile
 	std::conditional_t<(x < (1ULL<<32)), Profile::u32, Profile::u64>>>
 
 /*!
+@brief The macro used to adapt the type of the integer used to iterate over the
+		Profile Blocks based on the value of the max number of profile blocks (NB_TIMINGS).
+*/
+#define IT_TIMINGS_TYPE U_SIZE_ADAPTER(NB_TIMINGS)
+
+/*!
+@brief The macro used to adapt the type of the integer used to iterate over the
+		Profile Tracks based on the value of the max number of profile tracks (NB_TRACKS).
+*/
+#define IT_TRACKS_TYPE U_SIZE_ADAPTER(NB_TRACKS)
+
+/*!
 @brief The macro used to adapt the type of the different variables used to
 		represent the number or index of Profile Blocks based on the value of the 
 		max number of profile blocks (NB_TIMINGS).

--- a/headers/Profile/Profiler.hpp
+++ b/headers/Profile/Profiler.hpp
@@ -840,13 +840,6 @@ public:
 	PROFILE_API void ComputeStdResults(u64 _repetitionCount) noexcept;
 
 	/*!
-	@brief Cumulates the results of the repeated profiling.
-	@param _repetitionCount The number of repetitions.
-	@see ::cumulatedResults
-	*/
-	PROFILE_API void CumulateResults(u64 _repetitionCount) noexcept;
-
-	/*!
 	@brief Goes through the repeated profiling to find the maximum results.
 	@details In the current implementation, there is no guarentee that the
 			 maximum results all come from the same repetition. For example,

--- a/headers/Profile/Profiler.hpp
+++ b/headers/Profile/Profiler.hpp
@@ -708,11 +708,6 @@ struct RepetitionProfiler
 	ProfilerResults averageResults;
 
 	/*!
-	@brief A result structure to store the cumulated results of the repeated profiling.
-	*/
-	ProfilerResults cumulatedResults;
-
-	/*!
 	@brief A result structure to store the maximum of the repeated profiling.
 	*/
 	ProfilerResults maxResults;

--- a/headers/Profile/Profiler.hpp
+++ b/headers/Profile/Profiler.hpp
@@ -718,9 +718,9 @@ struct RepetitionProfiler
 	ProfilerResults minResults;
 
 	/*!
-	@brief A result structure to store the standard deviation of the repeated profiling.
+	@brief A result structure to store the variance of the repeated profiling.
 	*/
-	ProfilerResults stdResults;
+	ProfilerResults varianceResults;
 
 	/*!
 	@brief Sets the pointer for ::ptr_repetitionResults.
@@ -840,11 +840,11 @@ public:
 	PROFILE_API void ComputeAverageResults(u64 _repetitionCount) noexcept;
 
 	/*!
-	@brief Computes the standard deviation of the repeated profiling.
+	@brief Computes the variance of the repeated profiling.
 	@param _repetitionCount The number of repetitions.
-	@see ::stdResults
+	@see ::varianceResults
 	*/
-	PROFILE_API void ComputeStdResults(u64 _repetitionCount) noexcept;
+	PROFILE_API void ComputeVarianceResults(u64 _repetitionCount) noexcept;
 
 	/*!
 	@brief Goes through the repeated profiling to find the maximum results.
@@ -884,7 +884,7 @@ public:
 	@brief Prints the results of the repeated profiling.
 	@details If none have been computed yet (i.e., the corresponding Profile::ProfilingResults
 			 have their names set to nullptr), the function will compute the
-			 average, the standard deviation, the maximum, and the minimum of
+			 average, the variance, the maximum, and the minimum of
 			 the repeated profiling before outputting the results.
 	@param _repetitionCount The number of repetitions.
 	*/
@@ -892,7 +892,7 @@ public:
 
 	/*!
 	@brief Resets all the stored and computed results of the repeated profiling. 
-	@details The function will reset the values of ::averageResults, ::stdResults,
+	@details The function will reset the values of ::averageResults, ::varianceResults,
 			 ::cumulatedResults, ::maxResults, and ::minResults. It also resets
 			 everything in the ProfilerResults pointed by ::ptr_repetitionResults.
 	@param _repetitionCount The number of repetitions.

--- a/src/Profile/Profiler.cpp
+++ b/src/Profile/Profiler.cpp
@@ -63,8 +63,6 @@ void Profile::ProfileBlockResult::Report() noexcept
 
 void Profile::ProfileBlockResult::Reset() noexcept
 {
-	trackIdx = 0;
-	profileBlockRecorderIdx = 0;
 	elapsed = 0;
 	elapsedSec = 0.0;
 	hitCount = 0;

--- a/src/Profile/Profiler.cpp
+++ b/src/Profile/Profiler.cpp
@@ -147,7 +147,7 @@ void Profile::ProfileTrackResult::Report() noexcept
 
 void Profile::ProfileTrackResult::Reset() noexcept
 {
-	for (NB_TIMINGS_TYPE i = 0; i < blockCount; ++i)
+	for (IT_TIMINGS_TYPE i = 0; i < blockCount; ++i)
 	{
 		timings[i].Reset();
 	}
@@ -252,7 +252,7 @@ void Profile::ProfilerResults::Report() noexcept
 {
 	printf("\n---- ProfilerResults: %s (%fms) ----\n", name, 1000 * elapsedSec);
 	
-	for (NB_TRACKS_TYPE i = 0; i < trackCount; ++i)
+	for (IT_TRACKS_TYPE i = 0; i < trackCount; ++i)
 	{
 		tracks[i].Report();
 	}
@@ -260,7 +260,7 @@ void Profile::ProfilerResults::Report() noexcept
 
 void Profile::ProfilerResults::Reset() noexcept
 {
-	for (NB_TRACKS_TYPE i = 0; i < trackCount; ++i)
+	for (IT_TRACKS_TYPE i = 0; i < trackCount; ++i)
 	{
 		tracks[i].Reset();
 	}
@@ -334,20 +334,16 @@ void Profile::RepetitionProfiler::ComputeStdResults(u64 _repetitionCount) noexce
 		stdResults.elapsed += (ptr_repetitionResults[i].elapsed - averageResults.elapsed)* (ptr_repetitionResults[i].elapsed - averageResults.elapsed);
 		stdResults.elapsedSec += (ptr_repetitionResults[i].elapsedSec - averageResults.elapsedSec) * (ptr_repetitionResults[i].elapsedSec - averageResults.elapsedSec);
 		if (stdResults.trackCount < ptr_repetitionResults[i].trackCount)
-		{
 			stdResults.trackCount = ptr_repetitionResults[i].trackCount;
-		}
-		for (NB_TRACKS_TYPE j = 0; j < ptr_repetitionResults[i].trackCount; ++j)
+		for (IT_TRACKS_TYPE j = 0; j < ptr_repetitionResults[i].trackCount; ++j)
 		{
 			stdResults.tracks[j].name = ptr_repetitionResults[i].tracks[j].name;
 			stdResults.tracks[j].elapsed += (ptr_repetitionResults[i].tracks[j].elapsed - averageResults.tracks[j].elapsed) * (ptr_repetitionResults[i].tracks[j].elapsed - averageResults.tracks[j].elapsed);
 			stdResults.tracks[j].elapsedSec += (ptr_repetitionResults[i].tracks[j].elapsedSec - averageResults.tracks[j].elapsedSec) * (ptr_repetitionResults[i].tracks[j].elapsedSec - averageResults.tracks[j].elapsedSec);
 			stdResults.tracks[j].proportionInTotal += (ptr_repetitionResults[i].tracks[j].proportionInTotal - averageResults.tracks[j].proportionInTotal) * (ptr_repetitionResults[i].tracks[j].proportionInTotal - averageResults.tracks[j].proportionInTotal);
 			if (stdResults.tracks[j].blockCount < ptr_repetitionResults[i].tracks[j].blockCount)
-			{
 				stdResults.tracks[j].blockCount = ptr_repetitionResults[i].tracks[j].blockCount;
-			}
-			for (NB_TIMINGS_TYPE k = 0; k < ptr_repetitionResults[i].tracks[j].blockCount; ++k)
+			for (IT_TIMINGS_TYPE k = 0; k < ptr_repetitionResults[i].tracks[j].blockCount; ++k)
 			{
 				stdResults.tracks[j].timings[k].blockName = ptr_repetitionResults[i].tracks[j].timings[k].blockName;
 				stdResults.tracks[j].timings[k].elapsed += (ptr_repetitionResults[i].tracks[j].timings[k].elapsed - averageResults.tracks[j].timings[k].elapsed) * (ptr_repetitionResults[i].tracks[j].timings[k].elapsed - averageResults.tracks[j].timings[k].elapsed);
@@ -369,20 +365,16 @@ void Profile::RepetitionProfiler::FindMaxResults(u64 _repetitionCount) noexcept
 		MaxAssign(maxResults.elapsed, ptr_repetitionResults[i].elapsed);
 		MaxAssign(maxResults.elapsedSec, ptr_repetitionResults[i].elapsedSec);
 		if (maxResults.trackCount < ptr_repetitionResults[i].trackCount)
-		{
 			maxResults.trackCount = ptr_repetitionResults[i].trackCount;
-		}
-		for (NB_TRACKS_TYPE j = 0; j < ptr_repetitionResults[i].trackCount; ++j)
+		for (IT_TRACKS_TYPE j = 0; j < ptr_repetitionResults[i].trackCount; ++j)
 		{
 			maxResults.tracks[j].name = ptr_repetitionResults[i].tracks[j].name;
 			MaxAssign(maxResults.tracks[j].elapsed, ptr_repetitionResults[i].tracks[j].elapsed);
 			MaxAssign(maxResults.tracks[j].elapsedSec, ptr_repetitionResults[i].tracks[j].elapsedSec);
 			MaxAssign(maxResults.tracks[j].proportionInTotal, ptr_repetitionResults[i].tracks[j].proportionInTotal);
 			if (maxResults.tracks[j].blockCount < ptr_repetitionResults[i].tracks[j].blockCount)
-			{
 				maxResults.tracks[j].blockCount = ptr_repetitionResults[i].tracks[j].blockCount;
-			}
-			for (NB_TIMINGS_TYPE k = 0; k < ptr_repetitionResults[i].tracks[j].blockCount; ++k)
+			for (IT_TIMINGS_TYPE k = 0; k < ptr_repetitionResults[i].tracks[j].blockCount; ++k)
 			{
 				maxResults.tracks[j].timings[k].blockName = ptr_repetitionResults[i].tracks[j].timings[k].blockName;
 				MaxAssign(maxResults.tracks[j].timings[k].elapsed, ptr_repetitionResults[i].tracks[j].timings[k].elapsed);
@@ -403,21 +395,17 @@ void Profile::RepetitionProfiler::FindMinResults(u64 _repetitionCount) noexcept
 	{
 		MinAssign(minResults.elapsed, ptr_repetitionResults[i].elapsed);
 		MinAssign(minResults.elapsedSec, ptr_repetitionResults[i].elapsedSec);
-		if (minResults.trackCount > ptr_repetitionResults[i].trackCount)
-		{
+		if (minResults.trackCount < ptr_repetitionResults[i].trackCount)
 			minResults.trackCount = ptr_repetitionResults[i].trackCount;
-		}
-		for (NB_TRACKS_TYPE j = 0; j < ptr_repetitionResults[i].trackCount; ++j)
+		for (IT_TRACKS_TYPE j = 0; j < ptr_repetitionResults[i].trackCount; ++j)
 		{
 			minResults.tracks[j].name = ptr_repetitionResults[i].tracks[j].name;
 			MinAssign(minResults.tracks[j].elapsed, ptr_repetitionResults[i].tracks[j].elapsed);
 			MinAssign(minResults.tracks[j].elapsedSec, ptr_repetitionResults[i].tracks[j].elapsedSec);
 			MinAssign(minResults.tracks[j].proportionInTotal, ptr_repetitionResults[i].tracks[j].proportionInTotal);
-			if (minResults.tracks[j].blockCount > ptr_repetitionResults[i].tracks[j].blockCount)
-			{
+			if (minResults.tracks[j].blockCount < ptr_repetitionResults[i].tracks[j].blockCount)
 				minResults.tracks[j].blockCount = ptr_repetitionResults[i].tracks[j].blockCount;
-			}
-			for (NB_TIMINGS_TYPE k = 0; k < ptr_repetitionResults[i].tracks[j].blockCount; ++k)
+			for (IT_TIMINGS_TYPE k = 0; k < ptr_repetitionResults[i].tracks[j].blockCount; ++k)
 			{
 				minResults.tracks[j].timings[k].blockName = ptr_repetitionResults[i].tracks[j].timings[k].blockName;
 				MinAssign(minResults.tracks[j].timings[k].elapsed, ptr_repetitionResults[i].tracks[j].timings[k].elapsed);

--- a/src/Profile/Profiler.cpp
+++ b/src/Profile/Profiler.cpp
@@ -147,14 +147,14 @@ void Profile::ProfileTrackResult::Report() noexcept
 
 void Profile::ProfileTrackResult::Reset() noexcept
 {
-	elapsed = 0;
-	elapsedSec = 0.0;
-	proportionInTotal = 0.0;
-	blockCount = 0;
 	for (NB_TIMINGS_TYPE i = 0; i < blockCount; ++i)
 	{
 		timings[i].Reset();
 	}
+	elapsed = 0;
+	elapsedSec = 0.0;
+	proportionInTotal = 0.0;
+	blockCount = 0;
 }
 
 NB_TIMINGS_TYPE Profile::Profiler::GetProfileBlockRecorderIndex(NB_TRACKS_TYPE _trackIdx,
@@ -260,12 +260,12 @@ void Profile::ProfilerResults::Report() noexcept
 
 void Profile::ProfilerResults::Reset() noexcept
 {
-	elapsed = 0;
-	trackCount = 0;
-	for (NB_TRACKS_TYPE i = 0; i < NB_TRACKS; ++i)
+	for (NB_TRACKS_TYPE i = 0; i < trackCount; ++i)
 	{
 		tracks[i].Reset();
 	}
+	elapsed = 0;
+	trackCount = 0;
 }
 
 void Profile::RepetitionProfiler::ComputeAverageResults(u64 _repetitionCount) noexcept

--- a/src/Profile/Profiler.cpp
+++ b/src/Profile/Profiler.cpp
@@ -321,7 +321,7 @@ void Profile::RepetitionProfiler::ComputeAverageResults(u64 _repetitionCount) no
 	}
 }
 
-void Profile::RepetitionProfiler::ComputeStdResults(u64 _repetitionCount) noexcept
+void Profile::RepetitionProfiler::ComputeVarianceResults(u64 _repetitionCount) noexcept
 {
 	if (averageResults.name == nullptr)
 	{
@@ -331,27 +331,27 @@ void Profile::RepetitionProfiler::ComputeStdResults(u64 _repetitionCount) noexce
 	stdResults.name = averageResults.name;
 	for (u64 i = 0; i < _repetitionCount; ++i)
 	{
-		stdResults.elapsed += (ptr_repetitionResults[i].elapsed - averageResults.elapsed)* (ptr_repetitionResults[i].elapsed - averageResults.elapsed);
-		stdResults.elapsedSec += (ptr_repetitionResults[i].elapsedSec - averageResults.elapsedSec) * (ptr_repetitionResults[i].elapsedSec - averageResults.elapsedSec);
-		if (stdResults.trackCount < ptr_repetitionResults[i].trackCount)
-			stdResults.trackCount = ptr_repetitionResults[i].trackCount;
+		varianceResults.elapsed += (ptr_repetitionResults[i].elapsed - averageResults.elapsed) * (ptr_repetitionResults[i].elapsed - averageResults.elapsed);
+		varianceResults.elapsedSec += (ptr_repetitionResults[i].elapsedSec - averageResults.elapsedSec) * (ptr_repetitionResults[i].elapsedSec - averageResults.elapsedSec);
+		if (varianceResults.trackCount < ptr_repetitionResults[i].trackCount)
+			varianceResults.trackCount = ptr_repetitionResults[i].trackCount;
 		for (IT_TRACKS_TYPE j = 0; j < ptr_repetitionResults[i].trackCount; ++j)
 		{
-			stdResults.tracks[j].name = ptr_repetitionResults[i].tracks[j].name;
-			stdResults.tracks[j].elapsed += (ptr_repetitionResults[i].tracks[j].elapsed - averageResults.tracks[j].elapsed) * (ptr_repetitionResults[i].tracks[j].elapsed - averageResults.tracks[j].elapsed);
-			stdResults.tracks[j].elapsedSec += (ptr_repetitionResults[i].tracks[j].elapsedSec - averageResults.tracks[j].elapsedSec) * (ptr_repetitionResults[i].tracks[j].elapsedSec - averageResults.tracks[j].elapsedSec);
-			stdResults.tracks[j].proportionInTotal += (ptr_repetitionResults[i].tracks[j].proportionInTotal - averageResults.tracks[j].proportionInTotal) * (ptr_repetitionResults[i].tracks[j].proportionInTotal - averageResults.tracks[j].proportionInTotal);
-			if (stdResults.tracks[j].blockCount < ptr_repetitionResults[i].tracks[j].blockCount)
-				stdResults.tracks[j].blockCount = ptr_repetitionResults[i].tracks[j].blockCount;
+			varianceResults.tracks[j].name = ptr_repetitionResults[i].tracks[j].name;
+			varianceResults.tracks[j].elapsed += (ptr_repetitionResults[i].tracks[j].elapsed - averageResults.tracks[j].elapsed) * (ptr_repetitionResults[i].tracks[j].elapsed - averageResults.tracks[j].elapsed);
+			varianceResults.tracks[j].elapsedSec += (ptr_repetitionResults[i].tracks[j].elapsedSec - averageResults.tracks[j].elapsedSec) * (ptr_repetitionResults[i].tracks[j].elapsedSec - averageResults.tracks[j].elapsedSec);
+			varianceResults.tracks[j].proportionInTotal += (ptr_repetitionResults[i].tracks[j].proportionInTotal - averageResults.tracks[j].proportionInTotal) * (ptr_repetitionResults[i].tracks[j].proportionInTotal - averageResults.tracks[j].proportionInTotal);
+			if (varianceResults.tracks[j].blockCount < ptr_repetitionResults[i].tracks[j].blockCount)
+				varianceResults.tracks[j].blockCount = ptr_repetitionResults[i].tracks[j].blockCount;
 			for (IT_TIMINGS_TYPE k = 0; k < ptr_repetitionResults[i].tracks[j].blockCount; ++k)
 			{
-				stdResults.tracks[j].timings[k].blockName = ptr_repetitionResults[i].tracks[j].timings[k].blockName;
-				stdResults.tracks[j].timings[k].elapsed += (ptr_repetitionResults[i].tracks[j].timings[k].elapsed - averageResults.tracks[j].timings[k].elapsed) * (ptr_repetitionResults[i].tracks[j].timings[k].elapsed - averageResults.tracks[j].timings[k].elapsed);
-				stdResults.tracks[j].timings[k].hitCount += (ptr_repetitionResults[i].tracks[j].timings[k].hitCount - averageResults.tracks[j].timings[k].hitCount) * (ptr_repetitionResults[i].tracks[j].timings[k].hitCount - averageResults.tracks[j].timings[k].hitCount);
-				stdResults.tracks[j].timings[k].processedByteCount += (ptr_repetitionResults[i].tracks[j].timings[k].processedByteCount - averageResults.tracks[j].timings[k].processedByteCount) * (ptr_repetitionResults[i].tracks[j].timings[k].processedByteCount - averageResults.tracks[j].timings[k].processedByteCount);
-				stdResults.tracks[j].timings[k].proportionInTrack += (ptr_repetitionResults[i].tracks[j].timings[k].proportionInTrack - averageResults.tracks[j].timings[k].proportionInTrack) * (ptr_repetitionResults[i].tracks[j].timings[k].proportionInTrack - averageResults.tracks[j].timings[k].proportionInTrack);
-				stdResults.tracks[j].timings[k].proportionInTotal += (ptr_repetitionResults[i].tracks[j].timings[k].proportionInTotal - averageResults.tracks[j].timings[k].proportionInTotal) * (ptr_repetitionResults[i].tracks[j].timings[k].proportionInTotal - averageResults.tracks[j].timings[k].proportionInTotal);
-				stdResults.tracks[j].timings[k].bandwidthInB += (ptr_repetitionResults[i].tracks[j].timings[k].bandwidthInB - averageResults.tracks[j].timings[k].bandwidthInB) * (ptr_repetitionResults[i].tracks[j].timings[k].bandwidthInB - averageResults.tracks[j].timings[k].bandwidthInB);
+				varianceResults.tracks[j].timings[k].blockName = ptr_repetitionResults[i].tracks[j].timings[k].blockName;
+				varianceResults.tracks[j].timings[k].elapsed += (ptr_repetitionResults[i].tracks[j].timings[k].elapsed - averageResults.tracks[j].timings[k].elapsed) * (ptr_repetitionResults[i].tracks[j].timings[k].elapsed - averageResults.tracks[j].timings[k].elapsed);
+				varianceResults.tracks[j].timings[k].hitCount += (ptr_repetitionResults[i].tracks[j].timings[k].hitCount - averageResults.tracks[j].timings[k].hitCount) * (ptr_repetitionResults[i].tracks[j].timings[k].hitCount - averageResults.tracks[j].timings[k].hitCount);
+				varianceResults.tracks[j].timings[k].processedByteCount += (ptr_repetitionResults[i].tracks[j].timings[k].processedByteCount - averageResults.tracks[j].timings[k].processedByteCount) * (ptr_repetitionResults[i].tracks[j].timings[k].processedByteCount - averageResults.tracks[j].timings[k].processedByteCount);
+				varianceResults.tracks[j].timings[k].proportionInTrack += (ptr_repetitionResults[i].tracks[j].timings[k].proportionInTrack - averageResults.tracks[j].timings[k].proportionInTrack) * (ptr_repetitionResults[i].tracks[j].timings[k].proportionInTrack - averageResults.tracks[j].timings[k].proportionInTrack);
+				varianceResults.tracks[j].timings[k].proportionInTotal += (ptr_repetitionResults[i].tracks[j].timings[k].proportionInTotal - averageResults.tracks[j].timings[k].proportionInTotal) * (ptr_repetitionResults[i].tracks[j].timings[k].proportionInTotal - averageResults.tracks[j].timings[k].proportionInTotal);
+				varianceResults.tracks[j].timings[k].bandwidthInB += (ptr_repetitionResults[i].tracks[j].timings[k].bandwidthInB - averageResults.tracks[j].timings[k].bandwidthInB) * (ptr_repetitionResults[i].tracks[j].timings[k].bandwidthInB - averageResults.tracks[j].timings[k].bandwidthInB);
 			}
 		}
 	}
@@ -440,7 +440,7 @@ void Profile::RepetitionProfiler::Report(u64 _repetitionCount) noexcept
 {
 #if PROFILER_ENABLED
 
-	ComputeStdResults(_repetitionCount);
+	ComputeVarianceResults(_repetitionCount);
 
 	FindMaxResults(_repetitionCount);
 
@@ -450,30 +450,36 @@ void Profile::RepetitionProfiler::Report(u64 _repetitionCount) noexcept
 	//standard deviation, the minimum and the maximum values
 	printf("\n---- ProfilerResults: %s ({%f, %f(+/-)%f, %f}ms) ----\n",
 		averageResults.name,
-		1000 * minResults.elapsedSec, 1000 * averageResults.elapsedSec, 1000 * std::sqrt(stdResults.elapsedSec), 1000 * maxResults.elapsedSec);
-	for (u64 i = 0; i < averageResults.trackCount; ++i)
+		1000 * minResults.elapsedSec, 1000 * averageResults.elapsedSec, 1000 * std::sqrt(varianceResults.elapsedSec), 1000 * maxResults.elapsedSec);
+	for (IT_TRACKS_TYPE i = 0; i < averageResults.trackCount; ++i)
 	{
-		printf("\n---- Profile Track Results: %s ({%f, %f(+/-)%f, %f}ms; {%.2f, %.2f(+/-)%.2f, %.2f}%% of total) ----\n",
-			averageResults.tracks[i].name,
-			1000 * minResults.tracks[i].elapsedSec, 1000 * averageResults.tracks[i].elapsedSec,	1000 * std::sqrt(stdResults.tracks[i].elapsedSec), 1000 * maxResults.tracks[i].elapsedSec,
-			minResults.tracks[i].proportionInTotal, averageResults.tracks[i].proportionInTotal,	std::sqrt(stdResults.tracks[i].proportionInTotal), maxResults.tracks[i].proportionInTotal);
-
-		for (NB_TIMINGS_TYPE j = 0; j < averageResults.tracks[i].blockCount; ++j)
+		if (averageResults.tracks[i].name != nullptr)
 		{
-			printf("%s[{%llu, %llu(+/-)%f, %llu}]: {%llu, %llu(+/-)%f, %llu} ({%.2f, %.2f(+/-)%.2f, %.2f}%% of track; {%.2f, %.2f(+/-)%.2f, %.2f}%% of total",
-				averageResults.tracks[i].timings[j].blockName,
-				minResults.tracks[i].timings[j].hitCount, averageResults.tracks[i].timings[j].hitCount, std::sqrt(stdResults.tracks[i].timings[j].hitCount), maxResults.tracks[i].timings[j].hitCount,
-				minResults.tracks[i].timings[j].elapsed, averageResults.tracks[i].timings[j].elapsed, std::sqrt(stdResults.tracks[i].timings[j].elapsed), maxResults.tracks[i].timings[j].elapsed,
-				minResults.tracks[i].timings[j].proportionInTrack, averageResults.tracks[i].timings[j].proportionInTrack, std::sqrt(stdResults.tracks[i].timings[j].proportionInTrack), maxResults.tracks[i].timings[j].proportionInTrack,
-				minResults.tracks[i].timings[j].proportionInTotal, averageResults.tracks[i].timings[j].proportionInTotal, std::sqrt(stdResults.tracks[i].timings[j].proportionInTotal), maxResults.tracks[i].timings[j].proportionInTotal);
-			if (averageResults.tracks[i].timings[j].processedByteCount > 0)
+			printf("\n---- Profile Track Results: %s ({%f, %f(+/-)%f, %f}ms; {%.2f, %.2f(+/-)%.2f, %.2f}%% of total) ----\n",
+				averageResults.tracks[i].name,
+				1000 * minResults.tracks[i].elapsedSec, 1000 * averageResults.tracks[i].elapsedSec,	1000 * std::sqrt(varianceResults.tracks[i].elapsedSec), 1000 * maxResults.tracks[i].elapsedSec,
+				minResults.tracks[i].proportionInTotal, averageResults.tracks[i].proportionInTotal,	std::sqrt(varianceResults.tracks[i].proportionInTotal), maxResults.tracks[i].proportionInTotal);
+
+			for (IT_TIMINGS_TYPE j = 0; j < averageResults.tracks[i].blockCount; ++j)
 			{
-				printf("; {%.3f, %.3f(+/-)%.3f, %.3f}MB at {%.3f, %.3f(+/-)%.3f, %.3f}MB/s | {%.3f, %.3f(+/-)%.3f, %.3f}GB/s",
-					(f32)minResults.tracks[i].timings[j].processedByteCount / (1 << 20), (f32)averageResults.tracks[i].timings[j].processedByteCount / (1 << 20), std::sqrt(stdResults.tracks[i].timings[j].processedByteCount) / (1 << 20), (f32)maxResults.tracks[i].timings[j].processedByteCount / (1 << 20),
-					minResults.tracks[i].timings[j].bandwidthInB / (1 << 20), averageResults.tracks[i].timings[j].bandwidthInB / (1 << 20),	std::sqrt(stdResults.tracks[i].timings[j].bandwidthInB) / (1 << 20), maxResults.tracks[i].timings[j].bandwidthInB / (1 << 20),
-					minResults.tracks[i].timings[j].bandwidthInB / (1 << 30), averageResults.tracks[i].timings[j].bandwidthInB / (1 << 30),	std::sqrt(stdResults.tracks[i].timings[j].bandwidthInB) / (1 << 30), maxResults.tracks[i].timings[j].bandwidthInB / (1 << 30));
+				if (averageResults.tracks[i].timings[j].blockName != nullptr)
+				{
+					printf("%s[{%llu, %llu(+/-)%f, %llu}]: {%llu, %llu(+/-)%f, %llu} ({%.2f, %.2f(+/-)%.2f, %.2f}%% of track; {%.2f, %.2f(+/-)%.2f, %.2f}%% of total",
+						averageResults.tracks[i].timings[j].blockName,
+						minResults.tracks[i].timings[j].hitCount, averageResults.tracks[i].timings[j].hitCount, std::sqrt(varianceResults.tracks[i].timings[j].hitCount), maxResults.tracks[i].timings[j].hitCount,
+						minResults.tracks[i].timings[j].elapsed, averageResults.tracks[i].timings[j].elapsed, std::sqrt(varianceResults.tracks[i].timings[j].elapsed), maxResults.tracks[i].timings[j].elapsed,
+						minResults.tracks[i].timings[j].proportionInTrack, averageResults.tracks[i].timings[j].proportionInTrack, std::sqrt(varianceResults.tracks[i].timings[j].proportionInTrack), maxResults.tracks[i].timings[j].proportionInTrack,
+						minResults.tracks[i].timings[j].proportionInTotal, averageResults.tracks[i].timings[j].proportionInTotal, std::sqrt(varianceResults.tracks[i].timings[j].proportionInTotal), maxResults.tracks[i].timings[j].proportionInTotal);
+					if (averageResults.tracks[i].timings[j].processedByteCount > 0)
+					{
+						printf("; {%.3f, %.3f(+/-)%.3f, %.3f}MB at {%.3f, %.3f(+/-)%.3f, %.3f}MB/s | {%.3f, %.3f(+/-)%.3f, %.3f}GB/s",
+							(f32)minResults.tracks[i].timings[j].processedByteCount / (1 << 20), (f32)averageResults.tracks[i].timings[j].processedByteCount / (1 << 20), std::sqrt(varianceResults.tracks[i].timings[j].processedByteCount) / (1 << 20), (f32)maxResults.tracks[i].timings[j].processedByteCount / (1 << 20),
+							minResults.tracks[i].timings[j].bandwidthInB / (1 << 20), averageResults.tracks[i].timings[j].bandwidthInB / (1 << 20),	std::sqrt(varianceResults.tracks[i].timings[j].bandwidthInB) / (1 << 20), maxResults.tracks[i].timings[j].bandwidthInB / (1 << 20),
+							minResults.tracks[i].timings[j].bandwidthInB / (1 << 30), averageResults.tracks[i].timings[j].bandwidthInB / (1 << 30),	std::sqrt(varianceResults.tracks[i].timings[j].bandwidthInB) / (1 << 30), maxResults.tracks[i].timings[j].bandwidthInB / (1 << 30));
+					}
+					printf(")\n");
+				}
 			}
-			printf(")\n");
 		}
 	}
 #else
@@ -484,7 +490,7 @@ void Profile::RepetitionProfiler::Report(u64 _repetitionCount) noexcept
 void Profile::RepetitionProfiler::Reset(u64 _repetitionCount) noexcept
 {
 	averageResults.Reset();
-	stdResults.Reset();
+	varianceResults.Reset();
 	maxResults.Reset();
 	minResults.Reset();
 	for (u64 i = 0; i < _repetitionCount; ++i)

--- a/src/Profile/Profiler.cpp
+++ b/src/Profile/Profiler.cpp
@@ -355,6 +355,27 @@ void Profile::RepetitionProfiler::ComputeVarianceResults(u64 _repetitionCount) n
 			}
 		}
 	}
+
+	// finish the standard deviation calculation for the whole profiler
+	varianceResults.elapsed = varianceResults.elapsed / _repetitionCount;
+	varianceResults.elapsedSec = varianceResults.elapsedSec / _repetitionCount;
+	for (IT_TRACKS_TYPE j = 0; j < varianceResults.trackCount; ++j)
+	{
+		// finish the standard deviation calculation for the current track
+		varianceResults.tracks[j].elapsed = varianceResults.tracks[j].elapsed / _repetitionCount;
+		varianceResults.tracks[j].elapsedSec = varianceResults.tracks[j].elapsedSec / _repetitionCount;
+		varianceResults.tracks[j].proportionInTotal = varianceResults.tracks[j].proportionInTotal / _repetitionCount;
+		for (IT_TIMINGS_TYPE k = 0; k < varianceResults.tracks[j].blockCount; ++k)
+		{
+			// finish the standard deviation calculation for the current block
+			varianceResults.tracks[j].timings[k].elapsed = varianceResults.tracks[j].timings[k].elapsed / _repetitionCount;
+			varianceResults.tracks[j].timings[k].hitCount = varianceResults.tracks[j].timings[k].hitCount / _repetitionCount;
+			varianceResults.tracks[j].timings[k].processedByteCount = varianceResults.tracks[j].timings[k].processedByteCount / _repetitionCount;
+			varianceResults.tracks[j].timings[k].proportionInTrack = varianceResults.tracks[j].timings[k].proportionInTrack / _repetitionCount;
+			varianceResults.tracks[j].timings[k].proportionInTotal = varianceResults.tracks[j].timings[k].proportionInTotal / _repetitionCount;
+			varianceResults.tracks[j].timings[k].bandwidthInB = varianceResults.tracks[j].timings[k].bandwidthInB / _repetitionCount;
+		}
+	}
 }
 
 void Profile::RepetitionProfiler::FindMaxResults(u64 _repetitionCount) noexcept

--- a/src/Profile/Profiler.cpp
+++ b/src/Profile/Profiler.cpp
@@ -323,12 +323,8 @@ void Profile::RepetitionProfiler::ComputeAverageResults(u64 _repetitionCount) no
 
 void Profile::RepetitionProfiler::ComputeVarianceResults(u64 _repetitionCount) noexcept
 {
-	if (averageResults.name == nullptr)
-	{
-		ComputeAverageResults(_repetitionCount);
-	}
+	ComputeAverageResults(_repetitionCount);
 
-	stdResults.name = averageResults.name;
 	for (u64 i = 0; i < _repetitionCount; ++i)
 	{
 		varianceResults.elapsed += (ptr_repetitionResults[i].elapsed - averageResults.elapsed) * (ptr_repetitionResults[i].elapsed - averageResults.elapsed);
@@ -380,7 +376,6 @@ void Profile::RepetitionProfiler::ComputeVarianceResults(u64 _repetitionCount) n
 
 void Profile::RepetitionProfiler::FindMaxResults(u64 _repetitionCount) noexcept
 {
-	maxResults.name = averageResults.name;
 	for (u64 i = 0; i < _repetitionCount; ++i)
 	{
 		MaxAssign(maxResults.elapsed, ptr_repetitionResults[i].elapsed);
@@ -411,7 +406,6 @@ void Profile::RepetitionProfiler::FindMaxResults(u64 _repetitionCount) noexcept
 
 void Profile::RepetitionProfiler::FindMinResults(u64 _repetitionCount) noexcept
 {
-	minResults.name = averageResults.name;
 	for (u64 i = 0; i < _repetitionCount; ++i)
 	{
 		MinAssign(minResults.elapsed, ptr_repetitionResults[i].elapsed);
@@ -446,6 +440,11 @@ void Profile::RepetitionProfiler::FixedCountRepetitionTesting(u64 _repetitionCou
 
 	ptr_profiler->Reset();
 	Reset(_repetitionCount);
+
+	averageResults.name = ptr_profiler->name;
+	maxResults.name = ptr_profiler->name;
+	minResults.name = ptr_profiler->name;
+	varianceResults.name = ptr_profiler->name;
 
 	for (u64 i = 0; i < _repetitionCount; ++i)
 	{

--- a/src/Profile/Profiler.cpp
+++ b/src/Profile/Profiler.cpp
@@ -483,7 +483,6 @@ void Profile::RepetitionProfiler::Report(u64 _repetitionCount) noexcept
 
 void Profile::RepetitionProfiler::Reset(u64 _repetitionCount) noexcept
 {
-	cumulatedResults.Reset();
 	averageResults.Reset();
 	stdResults.Reset();
 	maxResults.Reset();

--- a/src/Tests/main.cpp
+++ b/src/Tests/main.cpp
@@ -94,7 +94,6 @@ void TestFunction_FixedRepetitionTesting()
 
 	repetitionProfiler->SetRepetitionResults(results);
 	repetitionProfiler->FixedCountRepetitionTesting(repetitionCount, repetitionTest);
-	repetitionProfiler->ComputeAverageResults(repetitionCount);
 	repetitionProfiler->Report(repetitionCount);
 
 	free(results);

--- a/src/Tests/main.cpp
+++ b/src/Tests/main.cpp
@@ -88,7 +88,7 @@ void TestFunction_FixedRepetitionTesting()
 	Profile::u64* arr = (Profile::u64*)malloc(sizeof(Profile::u64) * 8192);
 	RepetitionTest_TestFunction_ProfileFunction repetitionTest(arr, 8192);
 
-	Profile::u8 repetitionCount = 100;
+	Profile::u16 repetitionCount = 1000;
 	Profile::RepetitionProfiler* repetitionProfiler = (Profile::RepetitionProfiler*)calloc(1, sizeof(Profile::RepetitionProfiler));
 	Profile::ProfilerResults* results = (Profile::ProfilerResults*)calloc(repetitionCount, sizeof(Profile::ProfilerResults));
 
@@ -122,6 +122,11 @@ int main()
 	profiler->End();
 	profiler->Report();
 
+	TestFunction_FixedRepetitionTesting();
+
+	// Run the repetition profiling a second time to check that the internal 
+	// reset works appropriately. The profiling results should be close to the
+	// first run.
 	TestFunction_FixedRepetitionTesting();
 	
 	free(arr);

--- a/src/Tests/main.cpp
+++ b/src/Tests/main.cpp
@@ -27,7 +27,7 @@ void TestFunction_ProfileBlock(Profile::u64 _arr[], Profile::u64 _count)
 {
 	for (Profile::u64 i = 0; i < _count; ++i)
 	{
-		PROFILE_BLOCK_TIME("TestFunction_ProfileBlock_Write", 0);
+		PROFILE_BLOCK_TIME(TestFunction_ProfileBlock_Write, 0);
 		_arr[i] = i;
 	}
 }


### PR DESCRIPTION
Major:
- The calculation of the standard deviation was flawed. I had forgotten to devide by the number of samples
- For ease of display of the report later, we are not computing the standard deviation anymore but the Variance. It just means we are doing the square root at printing time.

Minor:
- Execution flow was slightly alterred with no visible effects on results until now.
- Tested that the `Reset` was likely working by running twice the `TestFunction_FixedRepetitionTesting` 