### PR TITLE
Fix - Over reporting on blocks that were resetted

### DIFF
--- a/src/Profile/Profiler.cpp
+++ b/src/Profile/Profiler.cpp
@@ -237,6 +237,7 @@ void Profile::ProfilerResults::Capture(Profiler* _profiler) noexcept
 	name = _profiler->name;
 	elapsed = _profiler->elapsed;
 	elapsedSec = (f64)_profiler->elapsed / (f64)Timer::GetEstimatedCPUFreq();
+	trackCount = 0;
 	NB_TRACKS_TYPE trackIdx = 0;
 	for (ProfileTrack& track : _profiler->tracks)
 	{

--- a/src/Profile/Profiler.cpp
+++ b/src/Profile/Profiler.cpp
@@ -78,6 +78,7 @@ void Profile::ProfileTrackResult::Capture(ProfileTrack& _track, u64 _trackIdx, u
 	elapsed = _track.elapsed;
 	elapsedSec = (f64)_track.elapsed / (f64)Timer::GetEstimatedCPUFreq();
 	proportionInTotal = _totalElapsedReference == 0 ? 0 : 100.0f * (f64)_track.elapsed / (f64)_totalElapsedReference;
+	blockCount = 0;
 	NB_TIMINGS_TYPE _profileBlockRecorderIdx = 0;
 	for (ProfileBlockRecorder record : _track.timings)
 	{


### PR DESCRIPTION
The fix was to make sure the capture of the profiling results for the number of tracks or blocks was reinitialized at 0.