### PR TITLE
[Add - Minor] `Clear` Interface

### DIFF
--- a/headers/Profile/Profiler.hpp
+++ b/headers/Profile/Profiler.hpp
@@ -196,6 +196,14 @@ struct ProfileBlockRecorder
 	u64 processedByteCount = 0;
 
 	/*!
+	@brief Clears the values of the block.
+	@remarks This resets even the ::blockName.
+			 If you are looking to reset the values without changing the name,
+			 use ::Reset.
+	*/
+	PROFILE_API void Clear() noexcept;
+
+	/*!
 	@brief Update the profiling statistics of the block upon completion.
 	@return The time increment since the block was opened.
 	*/
@@ -302,6 +310,15 @@ struct ProfileBlockResult
 				NB_TIMINGS_TYPE _profileBlockRecorderIdx, u64 _trackElapsedReference, u64 _totalElapsedReference) noexcept;
 
 	/*!
+	@brief Clears the values of the block.
+	@remarks This resets even the ::blockName.
+			 If you are looking to reset the values without changing the name,
+			 use ::Reset.
+
+	*/
+	PROFILE_API void Clear() noexcept;
+
+	/*!
 	@brief Outputs the profiling statistics of the block.
 	*/
 	PROFILE_API void Report() noexcept;
@@ -342,6 +359,21 @@ struct ProfileTrack
 	@brief The profiling statistics of the blocks in the track.
 	*/
 	std::array<ProfileBlockRecorder, NB_TIMINGS> timings;
+
+	/*
+	@brief Clears the values of the track and its blocks.
+	@remarks This resets even the ::name and ::elapsed.
+			 If you are looking to reset the values without changing the name,
+			 use ::Reset.
+			 If you are looking to reset the timings only, use ::ResetTimings.
+	*/
+	PROFILE_API void Clear() noexcept;
+
+	/*
+	@brief Clears the values of all blocks in ::timings.
+	@remarks This also resets ::hasBlock to false.
+	*/
+	PROFILE_API void ClearTimings() noexcept;
 
 	/*!
 	@brief Closes a block and updates the track's elapsed time.
@@ -442,6 +474,15 @@ struct ProfileTrackResult
 	PROFILE_API void Capture(ProfileTrack& _track, u64 _trackIdx, u64 _totalElapsedReference) noexcept;
 
 	/*!
+	@brief Clears the values of member variables of this struct and up to
+			::blockCount Profile::ProfileBlockResults in the ::timings array.
+	@remarks This resets even the ::name. 
+			 If you are looking to reset the values without changing the name,
+			 use ::Reset.
+	*/
+	PROFILE_API void Clear() noexcept;
+
+	/*!
 	@brief Outputs the profiling statistics of the track.
 	*/
 	PROFILE_API void Report() noexcept;
@@ -520,6 +561,22 @@ struct Profiler
 	}
 
 	/*!
+	@brief Clears the profiler's values as well as all its initialized tracks.
+	@remarks This resets even the ::name.
+			 If you are looking to reset the values without changing the name,
+			 use ::Reset.
+			 If you are looking to reset the tracks only, use ::ClearTracks.
+	*/
+	PROFILE_API void Clear() noexcept;
+
+	/*!
+	@brief Clears all used blocks of all used tracks in the profiler.
+	@remarks If you are looking to reset the values without changing the names,
+			 use ::ResetTracks.
+	*/
+	PROFILE_API void ClearTracks() noexcept;
+
+	/*!
 	@brief Closes a block.
 	@param _trackIdx The index of the track the block belongs to.
 	@param _profileBlockRecorderIdx The index of the profile result.
@@ -572,7 +629,7 @@ struct Profiler
 	@brief Resets the values of all blocks in all tracks that have a name.
 	@details Resetting do not change the names.
 	*/
-	PROFILE_API void ResetExistingTracks() noexcept;
+	PROFILE_API void ResetTracks() noexcept;
 };
 
 /*!
@@ -642,6 +699,15 @@ struct ProfilerResults
 			 of the profiler that have been used.
 	*/
 	PROFILE_API void Capture(Profiler* _profiler) noexcept;
+
+	/*!
+	@brief Clears the values of member variables of this struct and up to
+			::trackCount Profile::ProfileTrackResults in the ::tracks array.
+	@remarks This resets even the ::name.
+			 If you are looking to reset the values without changing the name,
+			 use ::Reset.
+	*/
+	PROFILE_API void Clear() noexcept;
 
 	/*!
 	@brief Outputs the profiling statistics of the profiler.
@@ -816,6 +882,19 @@ private:
 	}
 
 public:
+
+	/*!
+	@brief Clears all the stored and computed results of the repeated profiling.
+	@details The function will clear the values of ::averageResults, ::varianceResults,
+			 ::cumulatedResults, ::maxResults, and ::minResults. It also clears
+			 everything in the ProfilerResults pointed by ::ptr_repetitionResults.
+	@param _repetitionCount The number of repetitions.
+	@see Profile::ProfilerResults::Clear
+	@remarks If you don't want to clear the names of all the data concerned by the
+			 repeated profiling, you can use ::Reset.
+	*/
+	PROFILE_API void Clear(u64 _repetitionCount) noexcept;
+
 	/*!
 	@brief Computes the average of the repeated profiling.
 	@param _repetitionCount The number of repetitions.

--- a/headers/Profile/Profiler.hpp
+++ b/headers/Profile/Profiler.hpp
@@ -171,16 +171,6 @@ struct PROFILE_API ProfileBlock
 struct ProfileBlockRecorder
 {
 	/*!
-	@brief The line number in the file where the block is located.
-	*/
-	u32 lineNumber = 0;
-
-	/*!
-	@brief The name of the file where the block is located.
-	*/
-	const char* fileName = nullptr;
-
-	/*!
 	@brief The name of the block.
 	*/
 	const char* blockName = nullptr;
@@ -230,7 +220,7 @@ struct ProfileBlockRecorder
 
 	/*!
 	@brief Resets the values of the block.
-	@details Resetting do not change the ::blockName, the ::fileName, or the ::lineNumber.
+	@details Resetting do not change the ::blockName.
 	*/
 	PROFILE_API void Reset() noexcept;
 };
@@ -242,12 +232,6 @@ struct ProfileBlockRecorder
 struct ProfileBlockResult
 {
 	/*!
-	@brief The line number in the file where the block is located.
-	@details Mirrors ProfileBlockRecorder::lineNumber.
-	*/
-	u32 lineNumber = 0;
-
-	/*!
 	@brief The index of the profiling track this block belongs to.
 	@details No equivalent in ProfileBlockRecorder.
 	*/
@@ -258,12 +242,6 @@ struct ProfileBlockResult
 	@details No equivalent in ProfileBlockRecorder.
 	*/
 	NB_TIMINGS_TYPE profileBlockRecorderIdx = 0;
-
-	/*!
-	@brief The name of the file where the block is located.
-	@details Mirrors ProfileBlockRecorder::fileName.
-	*/
-	const char* fileName = nullptr;
 
 	/*!
 	@brief The name of the block.
@@ -330,7 +308,7 @@ struct ProfileBlockResult
 
 	/*!
 	@brief Resets the values of this struct.
-	@details Resetting do not change the ::blockName, the ::fileName, or the ::lineNumber.
+	@details Resetting do not change the ::blockName.
 	*/
 	PROFILE_API void Reset() noexcept;
 };

--- a/headers/Profile/Profiler.hpp
+++ b/headers/Profile/Profiler.hpp
@@ -940,8 +940,12 @@ public:
 			 of size @p _repetitionCount.
 	@param _repetitionCount The number of repetitions.
 	@param _repetitionTest The wrapper to the function to test.
+	@param _reset Whether to reset the results before testing. Default is true.
+				  See ::Reset, ::Profiler::Reset, and ::Profiler::ResetTracks.
+	@param _clear Whether to clear the results before testing. Default is false.
+				  See ::Clear, ::Profiler::Clear, and ::Profiler::ClearTracks.
 	*/
-	PROFILE_API void FixedCountRepetitionTesting(u64 _repetitionCount, RepetitionTest& _repetitionTest);
+	PROFILE_API void FixedCountRepetitionTesting(u64 _repetitionCount, RepetitionTest& _repetitionTest, bool _reset = true, bool _clear = false);
 
 	/*!
 	@brief Prints the results of the repeated profiling.

--- a/src/Profile/Profiler.cpp
+++ b/src/Profile/Profiler.cpp
@@ -14,10 +14,10 @@ Profile::Profiler* Profile::GetProfiler()
 	return s_Profiler;
 }
 
-Profile::ProfileBlock::ProfileBlock(NB_TRACKS_TYPE _trackIdx, NB_TIMINGS_TYPE _profileBlockRecorderIdx, u64 _byteCount) :
+Profile::ProfileBlock::ProfileBlock(NB_TRACKS_TYPE _trackIdx, const char* _blockName, NB_TIMINGS_TYPE _profileBlockRecorderIdx, u64 _byteCount) :
 	trackIdx(_trackIdx), profileBlockRecorderIdx(_profileBlockRecorderIdx)
 {
-	s_Profiler->OpenBlock(trackIdx, profileBlockRecorderIdx, _byteCount);
+	s_Profiler->OpenBlock(trackIdx, _blockName, profileBlockRecorderIdx, _byteCount);
 }
 
 Profile::ProfileBlock::~ProfileBlock()

--- a/src/Profile/Profiler.cpp
+++ b/src/Profile/Profiler.cpp
@@ -36,10 +36,8 @@ void Profile::ProfileBlockRecorder::Reset() noexcept
 void Profile::ProfileBlockResult::Capture(ProfileBlockRecorder& _record, NB_TRACKS_TYPE _trackIdx,
 	NB_TIMINGS_TYPE _profileBlockRecorderIdx, u64 _trackElapsedReference, u64 _totalElapsedReference) noexcept
 {
-	lineNumber = _record.lineNumber;
 	trackIdx = _trackIdx;
 	profileBlockRecorderIdx = _profileBlockRecorderIdx;
-	fileName = _record.fileName;
 	blockName = _record.blockName;
 	elapsed = _record.elapsed;
 	elapsedSec = (f64)_record.elapsed / (f64)Timer::GetEstimatedCPUFreq();
@@ -166,10 +164,7 @@ NB_TIMINGS_TYPE Profile::Profiler::GetProfileBlockRecorderIndex(NB_TRACKS_TYPE _
 	ProfileBlockRecorder* profileBlockRecorder = &s_Profiler->tracks[_trackIdx].timings[profileBlockRecorderIndex];
 	ProfileBlockRecorder* InitialprofileBlockRecorder = profileBlockRecorder;
 
-	// no need to compare _fileName and LinenNumber values, because for
-	// each (_fileName, _lineNumber) pair function will be called only once,
-	// so simply find first unused place in table
-	while (profileBlockRecorder->fileName)
+	while (profileBlockRecorder->blockName)
 	{
 		profileBlockRecorderIndex = (profileBlockRecorderIndex + 1) % NB_TIMINGS;
 		profileBlockRecorder = &s_Profiler->tracks[_trackIdx].timings[profileBlockRecorderIndex];
@@ -178,11 +173,6 @@ NB_TIMINGS_TYPE Profile::Profiler::GetProfileBlockRecorderIndex(NB_TRACKS_TYPE _
 		// than debug records we are putting in source code! Increase MAX_DEBUG_RECORD_COUNT!
 		//Assert(profileBlockRecorder != InitialprofileBlockRecorder);
 	}
-
-	s_Profiler->tracks[_trackIdx].hasBlock = true;
-	profileBlockRecorder->fileName = _fileName;
-	profileBlockRecorder->lineNumber = _lineNumber;
-	profileBlockRecorder->blockName = _blockName;
 
 	return profileBlockRecorderIndex;
 }

--- a/src/Profile/Profiler.cpp
+++ b/src/Profile/Profiler.cpp
@@ -524,12 +524,20 @@ void Profile::RepetitionProfiler::FindMinResults(u64 _repetitionCount) noexcept
 	}
 }
 
-void Profile::RepetitionProfiler::FixedCountRepetitionTesting(u64 _repetitionCount, RepetitionTest& _repetitionTest)
+void Profile::RepetitionProfiler::FixedCountRepetitionTesting(u64 _repetitionCount, RepetitionTest& _repetitionTest, bool _reset, bool _clear)
 {
 	Profiler* ptr_profiler = GetProfiler();
 
-	ptr_profiler->Reset();
-	Reset(_repetitionCount);
+	if (_reset && !_clear)
+	{
+		ptr_profiler->Reset();
+		Reset(_repetitionCount);
+	}
+	else if (_clear)
+	{
+		ptr_profiler->Reset();
+		Clear(_repetitionCount);
+	}
 
 	averageResults.name = ptr_profiler->name;
 	maxResults.name = ptr_profiler->name;

--- a/src/Tests/main.cpp
+++ b/src/Tests/main.cpp
@@ -116,12 +116,31 @@ int main()
 	TestFunction_ProfileBlock(arr, 8192);
 	TestFunction_Bandwidth(arr, 8192);
 
+	profiler->End();
+	profiler->Report();
+	profiler->ClearTracks();
+
 	profiler->SetTrackName(1, "SubTrack");
+	profiler->Initialize();
 	TestFunction_Track2(arr, 8192);
 
 	profiler->End();
 	profiler->Report();
+	profiler->ClearTracks();
 
+	profiler->SetTrackName(0, "Main");
+	profiler->Initialize();
+
+	TestFunction_ProfileFunction(arr, 8192);
+	TestFunction_ProfileBlock(arr, 8192);
+	TestFunction_Bandwidth(arr, 8192);
+
+	profiler->End();
+	profiler->Report();
+	profiler->ClearTracks();
+
+	profiler->SetProfilerName("FixedRepetitionTesting");
+	profiler->SetTrackName(0, "Main");
 	TestFunction_FixedRepetitionTesting();
 
 	// Run the repetition profiling a second time to check that the internal 


### PR DESCRIPTION
Currently, there was no way to bring back the data stored in a profiler and its mirror `ProfilerResults` to their values before any data was recorded. Indeed, `Reset` would leave the names of the blocks pending and only bring back the values of the measurements.

However, there are use cases where one might want to reuse the same instantiated profiler for widely different measurements. In these cases, `Reset` is lacking because a `Report` of the results would print empty measurements for every profiling block of the previous profiling session that were hit this time around in the new profiling session.

Hence, you can now
- manually call `Clear` the way we could call `Reset` on the profiler, its tracks, and the recorded blocks (same for the mirror structs with the _Result_ suffix). 
- Choose between `Clear`, `Reset`, or nothing in `FixedCountRepetitionTesting`