### PR TITLE
Best performance search

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -13,10 +13,10 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Clone Doxygen Awesome CSS
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: jothepro/doxygen-awesome-css
           ref: v2.3.2

--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
 
@@ -98,7 +98,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
 

--- a/.github/workflows/tests_macos.yml
+++ b/.github/workflows/tests_macos.yml
@@ -23,7 +23,7 @@ jobs:
         
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
 

--- a/.github/workflows/tests_windows.yml
+++ b/.github/workflows/tests_windows.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
 

--- a/headers/Profile/Profiler.hpp
+++ b/headers/Profile/Profiler.hpp
@@ -788,6 +788,15 @@ struct RepetitionProfiler
 private:
 
 	/*!
+	@brief The vector of the function wrappers to profile multiple times.
+	@details The functions will be profiled in the order they were added.
+			 It will be used in ::FixedCountRepetitionTesting, and ::BestPerfSearchRepetitionTesting
+	@see ::PushBackRepetitionTest, ::ClearRepetitionTests, ::RemoveRepetitionTest,
+		 ::PopBackRepetitionTest
+	*/
+	std::vector<RepetitionTest*> repetitionTests;
+
+	/*!
 	@brief A function to assign the maximum of two values to the first one.
 	@details The function is overloaded for u64, f32, and f64. It's used to
 			 lighten the code in ::FindMaxResults.
@@ -885,6 +894,43 @@ private:
 	}
 
 public:
+
+	/*!
+	@brief Pushes back a wrapper of a function to profile multiple times to
+			::repetitionTests.
+	*/
+	PROFILE_API inline void PushBackRepetitionTest(RepetitionTest* _repetitionTest) noexcept
+	{
+		repetitionTests.push_back(_repetitionTest);
+	}
+
+	/*!
+	@brief Clears all function wrappers in ::repetitionTests.
+	*/
+	PROFILE_API inline void ClearRepetitionTests() noexcept
+	{
+		repetitionTests.clear();
+	}
+
+	/*
+	@brief Removes a function wrapper from ::repetitionTests.
+	@param _index The index of the function wrapper to remove.
+	*/
+	PROFILE_API inline void RemoveRepetitionTest(u16 _index) noexcept
+	{
+		if (_index < repetitionTests.size())
+		{
+			repetitionTests.erase(repetitionTests.begin() + _index);
+		}
+	}
+
+	/*!
+	@brief Removes the function wrapper at the back of ::repetitionTests.
+	*/
+	PROFILE_API inline void PopBackRepetitionTest() noexcept
+	{
+		repetitionTests.pop_back();
+	}
 
 	/*!
 	@brief Clears all the stored and computed results of the repeated profiling.

--- a/headers/Profile/Profiler.hpp
+++ b/headers/Profile/Profiler.hpp
@@ -724,7 +724,7 @@ struct ProfilerResults
 
 /*!
 @brief A functor to wrap around code that will be profiled multiple times
-		via the ::RepetitionProfiler.
+		via the Profile::RepetitionProfiler.
 @see ::RepetitionProfiler::FixedCountRepetitionTesting
 */
 struct RepetitionTest
@@ -886,8 +886,8 @@ public:
 	/*!
 	@brief Clears all the stored and computed results of the repeated profiling.
 	@details The function will clear the values of ::averageResults, ::varianceResults,
-			 ::cumulatedResults, ::maxResults, and ::minResults. It also clears
-			 everything in the ProfilerResults pointed by ::ptr_repetitionResults.
+			 ::maxResults, and ::minResults. It also clears everything in the
+			 ProfilerResults pointed by ::ptr_repetitionResults.
 	@param _repetitionCount The number of repetitions.
 	@see Profile::ProfilerResults::Clear
 	@remarks If you don't want to clear the names of all the data concerned by the
@@ -960,8 +960,8 @@ public:
 	/*!
 	@brief Resets all the stored and computed results of the repeated profiling. 
 	@details The function will reset the values of ::averageResults, ::varianceResults,
-			 ::cumulatedResults, ::maxResults, and ::minResults. It also resets
-			 everything in the ProfilerResults pointed by ::ptr_repetitionResults.
+			 ::maxResults, and ::minResults. It also resets everything in the
+			 ProfilerResults pointed by ::ptr_repetitionResults.
 	@param _repetitionCount The number of repetitions.
 	@see Profile::ProfilerResults::Reset
 	*/

--- a/headers/Profile/Profiler.hpp
+++ b/headers/Profile/Profiler.hpp
@@ -934,6 +934,8 @@ public:
 	*/
 	PROFILE_API void FindMinResults(u64 _repetitionCount) noexcept;
 
+	PROFILE_API void BestPerfSearchRepetitionTesting(u16 _repetitionTestTimeOut, u8 _repetitionTestsCount, RepetitionTest* _repetitionTests, bool _reset = false, bool _clear = true, u16 _globalTimeOut = 0xFFFFu);
+
 	/*!
 	@brief Repeatedly tests a function and stores the profiling statistics.
 	@details The function will be called @p _repetitionCount times. The profiling

--- a/headers/Profile/Profiler.hpp
+++ b/headers/Profile/Profiler.hpp
@@ -2,6 +2,7 @@
 
 #include <array> // for the timings and tracks arrays
 #include <cstdio> // for printf
+#include <vector> // for storing the functions that will undergo the repetition testing
 #include <type_traits> // for std::conditional_t in U_SIZE_ADAPTER
 
 //#include "Export.hpp"
@@ -980,10 +981,29 @@ public:
 	*/
 	PROFILE_API void FindMinResults(u64 _repetitionCount) noexcept;
 
-	PROFILE_API void BestPerfSearchRepetitionTesting(u16 _repetitionTestTimeOut, u8 _repetitionTestsCount, RepetitionTest* _repetitionTests, bool _reset = false, bool _clear = true, u16 _globalTimeOut = 0xFFFFu);
+	/*!
+	@brief Repeatedly tests all functions wrapped in ::repetitionTests for as long
+			as allowed by the time out parameters and reports only about the best
+			performance.
+	@details The function will keep running until the @p _globalTimeOut is reached.
+			 We garentee that all functions will be tested at least once. When a 
+			 new best performance is found, the time out is reset by @p _repetitionTestTimeOut.
+			 The best profiling results of each function will be stored in the
+			 ProfilerResults pointed by ::ptr_repetitionResults. In this case,
+			 ::ptr_repetitionResults must be set before calling this function
+			 and must be an array of at least of size ::repetitionTests.size().
+	@param _repetitionTestTimeOut The time out in seconds for each repetition test.
+	@param _reset Whether to reset the results before testing. Default is false.
+				  See ::Reset, ::Profiler::Reset, and ::Profiler::ResetTracks.
+	@param _clear Whether to clear the results before testing. Default is true.
+					See ::Clear, ::Profiler::Clear, and ::Profiler::ClearTracks.
+	@param _globalTimeOut The time out in seconds for the whole testing.
+	*/
+	PROFILE_API void BestPerfSearchRepetitionTesting(u16 _repetitionTestTimeOut, bool _reset = false, bool _clear = true, u16 _globalTimeOut = 0xFFFFu);
 
 	/*!
-	@brief Repeatedly tests a function and stores the profiling statistics.
+	@brief Repeatedly tests all functions wrapped in ::repetitionTests and consecutively
+			reports the profiling statistics.
 	@details The function will be called @p _repetitionCount times. The profiling
 			 statistics of each repetition will be stored in the ProfilerResults
 			 pointed by ::ptr_repetitionResults. In this case, ::ptr_repetitionResults

--- a/headers/Profile/Profiler.hpp
+++ b/headers/Profile/Profiler.hpp
@@ -2,6 +2,7 @@
 
 #include <array> // for the timings and tracks arrays
 #include <cstdio> // for printf
+#include <cstdarg> // for va_list
 #include <vector> // for storing the functions that will undergo the repetition testing
 #include <type_traits> // for std::conditional_t in U_SIZE_ADAPTER
 
@@ -350,7 +351,7 @@ struct ProfileTrack
 	/*!
 	@brief The name of the track.
 	*/
-	const char* name = nullptr;
+	char name[32] = {0};
 
 	/*!
 	@brief The accumulated time from all blocks in the track.
@@ -554,14 +555,24 @@ struct Profiler
 	@brief Sets the name of a track.
 	@param _trackIdx The index of the track.
 	@param _name The name of the track.
+	@remarks The name will be truncated if it is longer than 31 characters.
 	*/
 	PROFILE_API inline void SetTrackName(NB_TRACKS_TYPE _trackIdx, const char* _name) noexcept
 	{
 		if (_trackIdx < NB_TRACKS)
 		{
-			tracks[_trackIdx].name = _name;
+			SetTrackNameFmt(_trackIdx, _name);
 		}
 	}
+	
+    /*!
+	@brief Sets the name of a track with a format string.
+	@param _trackIdx The index of the track.
+	@param _fmt The format string of the name of the track.
+	@param ... The arguments to the format string.
+	@remarks The name will be truncated if it is longer than 31 characters.
+	*/
+	PROFILE_API void SetTrackNameFmt(NB_TRACKS_TYPE _trackIdx, const char* _fmt, ...);
 
 	/*!
 	@brief Clears the profiler's values as well as all its initialized tracks.

--- a/headers/Profile/Profiler.hpp
+++ b/headers/Profile/Profiler.hpp
@@ -1004,8 +1004,11 @@ public:
 			as allowed by the time out parameters and reports only about the best
 			performance.
 	@details The function will keep running until the @p _globalTimeOut is reached.
-			 We garentee that all functions will be tested at least once. When a 
-			 new best performance is found, the time out is reset by @p _repetitionTestTimeOut.
+			 We garentee that all functions will be tested at least once. In
+			 particular, in case there is a user mistake and @p _globalTimeOut
+			 is shorter than @p _repetitionTestTimeOut, the latter will be used
+			 such that at least one test is done for each function. When a new
+			 best performance is found, the time out is reset by @p _repetitionTestTimeOut.
 			 The best profiling results of each function will be stored in the
 			 ProfilerResults pointed by ::ptr_repetitionResults. In this case,
 			 ::ptr_repetitionResults must be set before calling this function

--- a/headers/Profile/Profiler.hpp
+++ b/headers/Profile/Profiler.hpp
@@ -743,7 +743,15 @@ struct ProfilerResults
 */
 struct RepetitionTest
 {	
+	const char* name = nullptr;
+
 	RepetitionTest() = default;
+
+	/*!
+	@brief Constructs a RepetitionTest with a name.
+	@param _name The name of the test.
+	*/
+	RepetitionTest(const char* _name) : name(_name){}
 	~RepetitionTest() = default;
 
 	/*!

--- a/headers/Profile/Profiler.hpp
+++ b/headers/Profile/Profiler.hpp
@@ -507,7 +507,7 @@ struct Profiler
 	/*!
 	@brief The name of the profiler.
 	*/
-	const char* name = nullptr;
+	char name[64] = { 0 };
 
 	/*!
 	@brief The time when the profiler was initialized (when ::Initialize
@@ -526,10 +526,7 @@ struct Profiler
 	*/
 	std::array<ProfileTrack, NB_TRACKS> tracks;
 
-	Profiler(const char* _name) : name(_name)
-	{
-
-	}
+	Profiler() = default;
 
 	/*!
 	@brief Gets an index for a profile result.
@@ -548,8 +545,10 @@ struct Profiler
 	*/
 	PROFILE_API inline void SetProfilerName(const char* _name) noexcept
 	{
-		name = _name;
+		SetProfilerNameFmt(_name);
 	}
+
+	PROFILE_API void SetProfilerNameFmt(const char* _fmt, ...);
 
 	/*!
 	@brief Sets the name of a track.

--- a/headers/Profile/Profiler.hpp
+++ b/headers/Profile/Profiler.hpp
@@ -1012,7 +1012,7 @@ public:
 			 The best profiling results of each function will be stored in the
 			 ProfilerResults pointed by ::ptr_repetitionResults. In this case,
 			 ::ptr_repetitionResults must be set before calling this function
-			 and must be an array of at least of size ::repetitionTests.size().
+			 and must be an array of at least of the size of ::repetitionTests.
 	@param _repetitionTestTimeOut The time out in seconds for each repetition test.
 	@param _reset Whether to reset the results before testing. Default is false.
 				  See ::Reset, ::Profiler::Reset, and ::Profiler::ResetTracks.

--- a/headers/Profile/Profiler.hpp
+++ b/headers/Profile/Profiler.hpp
@@ -990,13 +990,12 @@ public:
 			 must be set before calling this function and must be an array of at least
 			 of size @p _repetitionCount.
 	@param _repetitionCount The number of repetitions.
-	@param _repetitionTest The wrapper to the function to test.
 	@param _reset Whether to reset the results before testing. Default is true.
 				  See ::Reset, ::Profiler::Reset, and ::Profiler::ResetTracks.
 	@param _clear Whether to clear the results before testing. Default is false.
 				  See ::Clear, ::Profiler::Clear, and ::Profiler::ClearTracks.
 	*/
-	PROFILE_API void FixedCountRepetitionTesting(u64 _repetitionCount, RepetitionTest& _repetitionTest, bool _reset = true, bool _clear = false);
+	PROFILE_API void FixedCountRepetitionTesting(u64 _repetitionCount, bool _reset = true, bool _clear = false);
 
 	/*!
 	@brief Prints the results of the repeated profiling.

--- a/headers/Profile/Profiler.hpp
+++ b/headers/Profile/Profiler.hpp
@@ -216,6 +216,7 @@ struct ProfileBlockRecorder
 
 	/*!
 	@brief Update the profiling statistics of the block upon execution.
+	@param _blockName The name given to this block.
 	@param _byteCount The number of bytes processed by the block.
 	*/
 	inline void Open(const char* _blockName, u64 _byteCount)
@@ -388,6 +389,7 @@ struct ProfileTrack
 	/*!
 	@brief Opens a block of the track.
 	@param _profileBlockRecorderIdx The index of the block timing in the track.
+	@param _blockName The name given to the block being profiled.
 	@param _byteCount The number of bytes processed by the block.
 	@see Profile::ProfileBlockRecorder::Open(Profile::u64 _byteCount)
 	*/
@@ -601,6 +603,7 @@ struct Profiler
 	/*!
 	@brief Opens a block.
 	@param _trackIdx The index of the track the block belongs to.
+	@param _blockName The name given to the block being profiled.
 	@param _profileBlockRecorderIdx The index of the profile result.
 	@param _byteCount The number of bytes processed by the block.
 	*/

--- a/src/Profile/Profiler.cpp
+++ b/src/Profile/Profiler.cpp
@@ -574,7 +574,10 @@ void Profile::RepetitionProfiler::BestPerfSearchRepetitionTesting(u16 _repetitio
 	Profiler* ptr_profiler = GetProfiler();
 
 	u64 nextTestTimeOut = 0;
-	u64 testGlobalTimeOut = Timer::GetCPUTimer() + max(_repetitionTestTimeOut, _globalTimeOut) * Timer::GetEstimatedCPUFreq();
+
+	//The inline comparison is equivalent to a max function.
+	//It's the only place where I need a max function so I didn't bother to implement one (and even less to include <algorithm> for it).
+	u64 testGlobalTimeOut = Timer::GetCPUTimer() + (_repetitionTestTimeOut >= _globalTimeOut ? _repetitionTestTimeOut : _globalTimeOut) * Timer::GetEstimatedCPUFreq();
 
 	u16 repetitionTestsCount = (u16)repetitionTests.size();
 	u64* bestPerfs = (u64*)malloc(repetitionTestsCount * sizeof(u64));

--- a/src/Profile/Profiler.cpp
+++ b/src/Profile/Profiler.cpp
@@ -232,6 +232,27 @@ NB_TIMINGS_TYPE Profile::Profiler::GetProfileBlockRecorderIndex(NB_TRACKS_TYPE _
 	return profileBlockRecorderIndex;
 }
 
+void Profile::Profiler::SetProfilerNameFmt(const char* _fmt, ...)
+{
+	//for security, check if the _fmt and the arguments is not bigger than the track name
+	std::va_list args;
+	va_start(args, _fmt);
+	int length = std::vsnprintf(nullptr, 0, _fmt, args);
+	va_end(args);
+
+	if (length > sizeof(name))
+	{
+		printf("Warning: Tried to a name for the profiler that is too long for the buffer. The name will be truncated.\n");
+	}
+
+	if (length > 0)
+	{
+		va_start(args, _fmt);
+		std::vsnprintf(name, sizeof(name), _fmt, args);
+		va_end(args);
+	}
+}
+
 void Profile::Profiler::SetTrackNameFmt(NB_TRACKS_TYPE _trackIdx, const char* _fmt, ...)
 {
 	if (_trackIdx < NB_TRACKS)
@@ -258,7 +279,7 @@ void Profile::Profiler::SetTrackNameFmt(NB_TRACKS_TYPE _trackIdx, const char* _f
 
 void Profile::Profiler::Clear() noexcept
 {
-	name = nullptr;
+	strcpy(name, "\0");
 	start = 0;
 	elapsed = 0;
 	ClearTracks();

--- a/src/Profile/Profiler.cpp
+++ b/src/Profile/Profiler.cpp
@@ -587,33 +587,38 @@ void Profile::RepetitionProfiler::BestPerfSearchRepetitionTesting(u16 _repetitio
 }
 
 
-void Profile::RepetitionProfiler::FixedCountRepetitionTesting(u64 _repetitionCount, RepetitionTest& _repetitionTest, bool _reset, bool _clear)
+void Profile::RepetitionProfiler::FixedCountRepetitionTesting(u64 _repetitionCount, bool _reset, bool _clear)
 {
 	Profiler* ptr_profiler = GetProfiler();
-
-	if (_reset && !_clear)
-	{
-		ptr_profiler->Reset();
-		Reset(_repetitionCount);
-	}
-	else if (_clear)
-	{
-		ptr_profiler->Clear();
-		Clear(_repetitionCount);
-	}
 
 	averageResults.name = ptr_profiler->name;
 	maxResults.name = ptr_profiler->name;
 	minResults.name = ptr_profiler->name;
 	varianceResults.name = ptr_profiler->name;
 
-	for (u64 i = 0; i < _repetitionCount; ++i)
+	for (RepetitionTest* _repetitionTest : repetitionTests)
 	{
-		ptr_profiler->Initialize();
-		_repetitionTest();
-		ptr_profiler->End();
-		ptr_repetitionResults[i].Capture(ptr_profiler);
-		ptr_profiler->ResetTracks();
+		if (_reset && !_clear)
+		{
+			ptr_profiler->Reset();
+			Reset(_repetitionCount);
+		}
+		else if (_clear)
+		{
+			ptr_profiler->Clear();
+			Clear(_repetitionCount);
+		}
+
+		for (u64 i = 0; i < _repetitionCount; ++i)
+		{
+			ptr_profiler->Initialize();
+			(*_repetitionTest)();
+			ptr_profiler->End();
+			ptr_repetitionResults[i].Capture(ptr_profiler);
+			ptr_profiler->ResetTracks();
+		}
+		
+		Report(_repetitionCount);
 	}
 }
 

--- a/src/Profile/Profiler.cpp
+++ b/src/Profile/Profiler.cpp
@@ -588,7 +588,7 @@ void Profile::RepetitionProfiler::BestPerfSearchRepetitionTesting(u16 _repetitio
 
 		while (Timer::GetCPUTimer() < testGlobalTimeOut)
 		{
-			for (int i = 0; i < repetitionTestsCount; i++)
+			for (u32 i = 0; i < repetitionTestsCount; i++)
 			{
 				if (_reset && !_clear)
 				{
@@ -599,6 +599,15 @@ void Profile::RepetitionProfiler::BestPerfSearchRepetitionTesting(u16 _repetitio
 				{
 					ptr_profiler->Clear();
 					Clear(repetitionTestsCount);
+
+					if (repetitionTests[i]->name)
+					{
+						ptr_profiler->SetProfilerName(repetitionTests[i]->name);
+					}
+					else
+					{
+						ptr_profiler->SetProfilerNameFmt("Best Perf Search Repetition Test %d", i);
+					}
 
 					//Give default names to the tracks in the profiler
 					for (NB_TRACKS_TYPE i = 0; i < NB_TRACKS; i++)
@@ -643,12 +652,7 @@ void Profile::RepetitionProfiler::FixedCountRepetitionTesting(u64 _repetitionCou
 {
 	Profiler* ptr_profiler = GetProfiler();
 
-	averageResults.name = ptr_profiler->name;
-	maxResults.name = ptr_profiler->name;
-	minResults.name = ptr_profiler->name;
-	varianceResults.name = ptr_profiler->name;
-
-	for (RepetitionTest* _repetitionTest : repetitionTests)
+	for (u32 i = 0; i < repetitionTests.size(); i++)
 	{
 		if (_reset && !_clear)
 		{
@@ -660,6 +664,20 @@ void Profile::RepetitionProfiler::FixedCountRepetitionTesting(u64 _repetitionCou
 			ptr_profiler->Clear();
 			Clear(_repetitionCount);
 
+			if (repetitionTests[i]->name)
+			{
+				ptr_profiler->SetProfilerName(repetitionTests[i]->name);
+			}
+			else
+			{
+				ptr_profiler->SetProfilerNameFmt("Fixed Count Repetition Test %d", i);
+			}
+
+			averageResults.name = ptr_profiler->name;
+			maxResults.name = ptr_profiler->name;
+			minResults.name = ptr_profiler->name;
+			varianceResults.name = ptr_profiler->name;
+
 			//Give default names to the tracks in the profiler
 			for (NB_TRACKS_TYPE i = 0; i < NB_TRACKS; i++)
 			{
@@ -667,12 +685,12 @@ void Profile::RepetitionProfiler::FixedCountRepetitionTesting(u64 _repetitionCou
 			}
 		}
 
-		for (u64 i = 0; i < _repetitionCount; ++i)
+		for (u64 j = 0; j < _repetitionCount; ++j)
 		{
 			ptr_profiler->Initialize();
-			(*_repetitionTest)();
+			(*repetitionTests[i])();
 			ptr_profiler->End();
-			ptr_repetitionResults[i].Capture(ptr_profiler);
+			ptr_repetitionResults[j].Capture(ptr_profiler);
 			ptr_profiler->ResetTracks();
 		}
 		

--- a/src/Profile/Profiler.cpp
+++ b/src/Profile/Profiler.cpp
@@ -586,7 +586,7 @@ void Profile::RepetitionProfiler::BestPerfSearchRepetitionTesting(u16 _repetitio
 	{
 		for (int i = 0; i < repetitionTestsCount; i++)
 		{
-			bestPerfs[i] = 0xffffffffffffffffui64;
+			bestPerfs[i] = 0xffffffffffffffffull;
 		}
 
 		while (Timer::GetCPUTimer() < testGlobalTimeOut)

--- a/src/Profile/Profiler.cpp
+++ b/src/Profile/Profiler.cpp
@@ -586,7 +586,7 @@ void Profile::RepetitionProfiler::BestPerfSearchRepetitionTesting(u16 _repetitio
 	{
 		for (int i = 0; i < repetitionTestsCount; i++)
 		{
-			bestPerfs[i] = SIZE_MAX;
+			bestPerfs[i] = 0xffffffffffffffffui64;
 		}
 
 		while (Timer::GetCPUTimer() < testGlobalTimeOut)

--- a/src/Tests/main.cpp
+++ b/src/Tests/main.cpp
@@ -48,6 +48,22 @@ struct RepetitionTest_TestFunction_ProfileFunction : public Profile::RepetitionT
 };
 
 /*!
+@brief A wrapper around the TestFunction_ProfileBlock when it will be used TestFunction_FixedRepetitionTesting.
+*/
+struct RepetitionTest_TestFunction_ProfileBlock : public Profile::RepetitionTest
+{
+	Profile::u64* arr = nullptr;
+	Profile::u64 count = 0;
+	RepetitionTest_TestFunction_ProfileBlock(Profile::u64* _arr, Profile::u64 _count) : arr(_arr), count(_count) {}
+
+	inline void operator()() override
+	{
+		TestFunction_ProfileBlock(arr, count);
+	}
+};
+
+
+/*!
 @brief Tests the macro time and bandwidth profiling macro on track 0: PROFILE_FUNCTION_TIME_BANDWIDTH(0, sizeof(Profile::u64) * _count).
 @details Fills an array with the index of the element.
 @param _arr The array to fill.
@@ -78,6 +94,20 @@ void TestFunction_Track2(Profile::u64 _arr[], Profile::u64 _count)
 		_arr[i] = i;
 	}
 }
+
+void TestFunction_BestPerfSearch()
+{
+	Profile::u64* arr = (Profile::u64*)malloc(sizeof(Profile::u64) * 8192);
+
+	Profile::RepetitionTest* repetitionTests = {
+		RepetitionTest_TestFunction_ProfileFunction(arr, 8192),
+		RepetitionTest_TestFunction_ProfileBlock(arr, 8192)
+	};
+
+	Profile::RepetitionProfiler::BestPerfSearchRepetitionTesting(3, 
+
+}
+
 
 /*!
 @brief Tests the FixedCountRepetitionTesting function of the RepetitionProfiler.
@@ -147,6 +177,9 @@ int main()
 	// reset works appropriately. The profiling results should be close to the
 	// first run.
 	TestFunction_FixedRepetitionTesting();
+
+
+
 	
 	free(arr);
 	free(profiler);

--- a/src/Tests/main.cpp
+++ b/src/Tests/main.cpp
@@ -97,15 +97,23 @@ void TestFunction_Track2(Profile::u64 _arr[], Profile::u64 _count)
 
 void TestFunction_BestPerfSearch()
 {
+
+	Profile::ProfilerResults* results = (Profile::ProfilerResults*)calloc(2, sizeof(Profile::ProfilerResults));
+	
+	Profile::RepetitionProfiler* repetitionProfiler = (Profile::RepetitionProfiler*)calloc(1, sizeof(Profile::RepetitionProfiler));
+	
 	Profile::u64* arr = (Profile::u64*)malloc(sizeof(Profile::u64) * 8192);
+	RepetitionTest_TestFunction_ProfileBlock repetitiontest(arr, 8192);
+	RepetitionTest_TestFunction_ProfileFunction repetitiontest2(arr, 8192);
+	repetitionProfiler->PushBackRepetitionTest(&repetitiontest);
+	repetitionProfiler->PushBackRepetitionTest(&repetitiontest2);
 
-	Profile::RepetitionTest* repetitionTests = {
-		RepetitionTest_TestFunction_ProfileFunction(arr, 8192),
-		RepetitionTest_TestFunction_ProfileBlock(arr, 8192)
-	};
+	repetitionProfiler->SetRepetitionResults(results);
+	repetitionProfiler->BestPerfSearchRepetitionTesting(3, false, true, 10);
 
-	Profile::RepetitionProfiler::BestPerfSearchRepetitionTesting(3, 
-
+	free(arr);
+	free(results);
+	free(repetitionProfiler);
 }
 
 
@@ -180,7 +188,7 @@ int main()
 	// first run.
 	TestFunction_FixedRepetitionTesting();
 
-
+	TestFunction_BestPerfSearch();
 
 	
 	free(arr);

--- a/src/Tests/main.cpp
+++ b/src/Tests/main.cpp
@@ -40,6 +40,7 @@ struct RepetitionTest_TestFunction_ProfileFunction : public Profile::RepetitionT
 	Profile::u64* arr = nullptr;
 	Profile::u64 count = 0;
 	RepetitionTest_TestFunction_ProfileFunction(Profile::u64* _arr, Profile::u64 _count) : arr(_arr), count(_count) {}
+	RepetitionTest_TestFunction_ProfileFunction(const char* _name, Profile::u64* _arr, Profile::u64 _count) : RepetitionTest(_name), arr(_arr), count(_count) {}
 
 	inline void operator()() override
 	{
@@ -55,6 +56,7 @@ struct RepetitionTest_TestFunction_ProfileBlock : public Profile::RepetitionTest
 	Profile::u64* arr = nullptr;
 	Profile::u64 count = 0;
 	RepetitionTest_TestFunction_ProfileBlock(Profile::u64* _arr, Profile::u64 _count) : arr(_arr), count(_count) {}
+	RepetitionTest_TestFunction_ProfileBlock(const char* _name, Profile::u64* _arr, Profile::u64 _count) : RepetitionTest(_name), arr(_arr), count(_count) {}
 
 	inline void operator()() override
 	{
@@ -103,7 +105,7 @@ void TestFunction_BestPerfSearch()
 	Profile::RepetitionProfiler* repetitionProfiler = (Profile::RepetitionProfiler*)calloc(1, sizeof(Profile::RepetitionProfiler));
 	
 	Profile::u64* arr = (Profile::u64*)malloc(sizeof(Profile::u64) * 8192);
-	RepetitionTest_TestFunction_ProfileBlock repetitiontest(arr, 8192);
+	RepetitionTest_TestFunction_ProfileBlock repetitiontest("TestFunction_ProfileBlock", arr, 8192);
 	RepetitionTest_TestFunction_ProfileFunction repetitiontest2(arr, 8192);
 	repetitionProfiler->PushBackRepetitionTest(&repetitiontest);
 	repetitionProfiler->PushBackRepetitionTest(&repetitiontest2);
@@ -179,8 +181,6 @@ int main()
 	profiler->Report();
 	profiler->ClearTracks();
 
-	profiler->SetProfilerName("FixedRepetitionTesting");
-	profiler->SetTrackName(0, "Main");
 	TestFunction_FixedRepetitionTesting();
 
 	// Run the repetition profiling a second time to check that the internal 

--- a/src/Tests/main.cpp
+++ b/src/Tests/main.cpp
@@ -116,15 +116,17 @@ void TestFunction_BestPerfSearch()
 void TestFunction_FixedRepetitionTesting()
 {
 	Profile::u64* arr = (Profile::u64*)malloc(sizeof(Profile::u64) * 8192);
-	RepetitionTest_TestFunction_ProfileFunction repetitionTest(arr, 8192);
 
 	Profile::u16 repetitionCount = 1000;
-	Profile::RepetitionProfiler* repetitionProfiler = (Profile::RepetitionProfiler*)calloc(1, sizeof(Profile::RepetitionProfiler));
 	Profile::ProfilerResults* results = (Profile::ProfilerResults*)calloc(repetitionCount, sizeof(Profile::ProfilerResults));
+	Profile::RepetitionProfiler* repetitionProfiler = (Profile::RepetitionProfiler*)calloc(1, sizeof(Profile::RepetitionProfiler));
+	
+	RepetitionTest_TestFunction_ProfileFunction repetitiontest(arr, 8192);
+	repetitionProfiler->PushBackRepetitionTest(&repetitiontest);
 
 	repetitionProfiler->SetRepetitionResults(results);
-	repetitionProfiler->FixedCountRepetitionTesting(repetitionCount, repetitionTest);
-	repetitionProfiler->Report(repetitionCount);
+	repetitionProfiler->FixedCountRepetitionTesting(repetitionCount);
+	
 
 	free(results);
 	free(repetitionProfiler);


### PR DESCRIPTION
## Major
- Implemented `BestPerfSearchRepetitionTesting` function. It is a time-limited search of the best performance for a `RepetitionTest`. The assumption is that if we find a new time minimum for the execution of a portion of code, maybe another one is available within a `t+dt` where `dt` is arbitrarily set by the user. This algorithm is only intended to give us an approximation of the best performances.

## Broken changes
- Re-designed how the `RepetitionTest` are passed to the repetition profiler. See `PushBackRepetitionTest`, `ClearRepetitionTests`, and `RemoveRepetitionTest` of the API of the Repetition Profiler. The basic idea is that repetition tests can be managed inside a vector and everything in the vector is tested if either `BestPerfSearchRepetitionTesting` or `FixedCountRepetitionTesting` are used.

## Minor
- Some CI fixes
